### PR TITLE
Improve subsystem matching in setdata()

### DIFF
--- a/inst/inst.rb
+++ b/inst/inst.rb
@@ -194,7 +194,9 @@ class Idb
     # bind the 1st unused entry for this name to its archive position
     def setdata(name, arc, pos)
 	@entries.each { |e|
-	    if e[:path] == name && e[:size] && ! e[:_archive] && e[:subsystem].start_with?(arc.name)
+	    if e[:path] == name && e[:size] && ! e[:_archive] && (
+			e[:subsystem].start_with?(arc.name) || arc.name.start_with?(e[:subsystem].gsub(/\..*$/, '')) ||
+			e[:unknown].start_with?(arc.name) || arc.name.start_with?(e[:unknown].gsub(/\..*$/, '')))
 		e[:_archive] = arc
 		e[:_position] = pos
 		return _length(e)


### PR DESCRIPTION
This fixes __some__ cases where inst.rb didn't correctly match the
subsystem name to the arc name. This is highlighted when attempting to
install the packages from the IRIX Network (ftp://ftp.irix.cc/pub/sgi-irix/irix-6.5/network-installs/irix-6.5.30/)

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>