### PR TITLE
Improve inst.rb and instlibs.rb

### DIFF
--- a/inst/inst.rb
+++ b/inst/inst.rb
@@ -194,7 +194,9 @@ class Idb
     # bind the 1st unused entry for this name to its archive position
     def setdata(name, arc, pos)
 	@entries.each { |e|
-	    if e[:path] == name && e[:size] && ! e[:_archive] && e[:subsystem].start_with?(arc.name)
+	    if e[:path] == name && e[:size] && ! e[:_archive] && (
+			e[:subsystem].start_with?(arc.name) || arc.name.start_with?(e[:subsystem].gsub(/\..*$/, '')) ||
+			e[:unknown].start_with?(arc.name) || arc.name.start_with?(e[:unknown].gsub(/\..*$/, '')))
 		e[:_archive] = arc
 		e[:_position] = pos
 		return _length(e)

--- a/inst/instlibs.sh
+++ b/inst/instlibs.sh
@@ -30,7 +30,7 @@ grep -e '\.so\>' -e '\<rld' $(find "$D" -name '*.idb') |
 			if [ "$cn" != "$n" -a -n "$cs" ]; then
 				# idb file changed, install stuff from old idb
 				echo "*** from $cn install $co:"
-				./inst.rb i "$cn" $cs -r"$R" $*
+                $(dirname $0)/inst.rb i "$cn" $cs -r"$R" $*
 				co=""; cs="";
 			fi
 			co="$co $s"; cs="$cs -s$s"
@@ -39,6 +39,6 @@ grep -e '\.so\>' -e '\<rld' $(find "$D" -name '*.idb') |
 		# install leftover packages from last idb
 		if [ -n "$cs" ]; then
 			echo "*** from $cn install $co:"
-			./inst.rb i "$cn" $cs -r"$R" $*
+			$(dirname $0)/inst.rb i "$cn" $cs -r"$R" $*
 		fi
 	)


### PR DESCRIPTION
In `inst.rb`:
- Improve subsystem matching when parsing the packages (this is better explained in #2 )

In `instlibs.rb`:
- Use `$(dirname $0)` instead of `./` when creating the path to execute `inst.rb`. This allows us to execute `instlibs.rb` from outside of the `inst` folder.